### PR TITLE
Change for loops with method each

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.idea
+/.DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-/.idea
-/.DS_Store
-

--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -154,9 +154,7 @@ module Forwardable
   def def_instance_delegators(accessor, *methods)
     methods.delete("__send__")
     methods.delete("__id__")
-    for method in methods
-      def_instance_delegator(accessor, method)
-    end
+    methods.each { |method|  def_instance_delegator(accessor, method) }
   end
 
   # Define +method+ as delegator instance method with an optional
@@ -286,9 +284,7 @@ module SingleForwardable
   def def_single_delegators(accessor, *methods)
     methods.delete("__send__")
     methods.delete("__id__")
-    for method in methods
-      def_single_delegator(accessor, method)
-    end
+    methods.each { |method| def_single_delegator(accessor, method) }
   end
 
   # :call-seq:

--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -132,11 +132,7 @@ module Forwardable
   #
   def instance_delegate(hash)
     hash.each do |methods, accessor|
-      if methods.respond_to?(:each)
-        methods.each { |method| def_instance_delegator(accessor, method) }
-      else
-        def_instance_delegator(accessor, methods)
-      end
+      def_instance_delegators(accessor, *Array(methods))
     end
   end
 

--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -132,10 +132,10 @@ module Forwardable
   #
   def instance_delegate(hash)
     hash.each do |methods, accessor|
-      unless defined?(methods.each)
-        def_instance_delegator(accessor, methods)
+      if methods.respond_to?(:each)
+        methods.each { |method| def_instance_delegator(accessor, method) }
       else
-        methods.each {|method| def_instance_delegator(accessor, method)}
+        def_instance_delegator(accessor, methods)
       end
     end
   end
@@ -262,10 +262,10 @@ module SingleForwardable
   #
   def single_delegate(hash)
     hash.each do |methods, accessor|
-      unless defined?(methods.each)
-        def_single_delegator(accessor, methods)
+      if methods.respond_to?(:each)
+        methods.each { |method| def_single_delegator(accessor, method) }
       else
-        methods.each {|method| def_single_delegator(accessor, method)}
+        def_single_delegator(accessor, methods)
       end
     end
   end

--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -258,11 +258,7 @@ module SingleForwardable
   #
   def single_delegate(hash)
     hash.each do |methods, accessor|
-      if methods.respond_to?(:each)
-        methods.each { |method| def_single_delegator(accessor, method) }
-      else
-        def_single_delegator(accessor, methods)
-      end
+      def_single_delegators(accessor, *Array(methods))
     end
   end
 


### PR DESCRIPTION
Hello)
I have changed 2 parts in current code:
1) Replaced **for loops** with **each** method I don't know any ruby developer, who uses for, everywhere only each, for this I have two arguments(code lines with 'for' were committed in 2011, I think ruby is modern and cool language) :
- Each looks more readable and cleaner
- For uses each under hood, so from functional side I don't change anything
2) Replaced defined? for respond_to?, respond_to? looks more readable, cleaner, it returns true or false, we are checking can our object respond to method each, we are not comparing defined result with all possible values of defined?('local-variable', 'class'), so I think, using defined? doesn't make any sense and only does code unreadable.
Sorry for my English.