### PR TITLE
Make def_{instance,single}_delegators skip :__send__ and :__id__

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -149,7 +149,7 @@ module Forwardable
   #
   def def_instance_delegators(accessor, *methods)
     methods.each do |method|
-      next if method.to_s == "__send__" || method.to_s == "__id__"
+      next if /\A__(?:send|id)__\z/ =~ method
       def_instance_delegator(accessor, method)
     end
   end
@@ -280,7 +280,7 @@ module SingleForwardable
   #
   def def_single_delegators(accessor, *methods)
     methods.each do |method|
-      next if method.to_s == "__send__" || method.to_s == "__id__"
+      next if /\A__(?:send|id)__\z/ =~ method
       def_single_delegator(accessor, method)
     end
   end

--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -148,9 +148,8 @@ module Forwardable
   #   def_delegator :@records, :map
   #
   def def_instance_delegators(accessor, *methods)
-    methods.delete("__send__")
-    methods.delete("__id__")
-    for method in methods
+    methods.each do |method|
+      next if method.to_s == "__send__" || method.to_s == "__id__"
       def_instance_delegator(accessor, method)
     end
   end
@@ -280,9 +279,8 @@ module SingleForwardable
   #   def_delegator :@records, :map
   #
   def def_single_delegators(accessor, *methods)
-    methods.delete("__send__")
-    methods.delete("__id__")
-    for method in methods
+    methods.each do |method|
+      next if method.to_s == "__send__" || method.to_s == "__id__"
       def_single_delegator(accessor, method)
     end
   end

--- a/test/test_forwardable.rb
+++ b/test/test_forwardable.rb
@@ -96,6 +96,18 @@ class TestForwardable < Test::Unit::TestCase
     end
   end
 
+  def test_def_instance_delegators_send_id
+    %i[def_delegators def_instance_delegators].each do |m|
+      cls = forwardable_class do
+        attr_reader :receiver
+        __send__ m, :@receiver, :__send__, :__id__
+      end
+
+      assert_not_equal cls.new.__id__, cls.new.receiver.__id__
+      assert_not_equal cls.new.__send__(:__id__), cls.new.receiver.__send__(:__id__)
+    end
+  end
+
   def test_instance_delegate
     %i[delegate instance_delegate].each do |m|
       cls = forwardable_class do
@@ -201,6 +213,18 @@ class TestForwardable < Test::Unit::TestCase
 
       assert_same RETURNED1, obj.delegated1
       assert_same RETURNED2, obj.delegated2
+    end
+  end
+
+  def test_obj_single_delegators_send_id
+    %i[def_delegators def_single_delegators].each do |m|
+      obj = single_forwardable_object do
+        singleton_class.attr_reader :receiver
+        __send__ m, :@receiver, :__send__, :__id__
+      end
+
+      assert_not_equal obj.__id__, obj.receiver.__id__
+      assert_not_equal obj.__send__(:__id__), obj.receiver.__send__(:__id__)
     end
   end
 


### PR DESCRIPTION
Previously, __send__ and __id__ were skipped if provided as strings,
but not skipped if provided as symbols.

Fixes Ruby Bug 8855.