### PR TITLE
Fix keyword argument separation warnings on Ruby 2.7+

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -183,7 +183,9 @@ module Forwardable
     gen = Forwardable._delegator_method(self, accessor, method, ali)
 
     # If it's not a class or module, it's an instance
-    (Module === self ? self : singleton_class).module_eval(&gen)
+    mod = Module === self ? self : singleton_class
+    mod.module_eval(&gen)
+    mod.send(:ruby2_keywords, ali) if RUBY_VERSION >= '2.7'
   end
 
   alias delegate instance_delegate
@@ -301,6 +303,7 @@ module SingleForwardable
     gen = Forwardable._delegator_method(self, accessor, method, ali)
 
     instance_eval(&gen)
+    singleton_class.send(:ruby2_keywords, ali) if RUBY_VERSION >= '2.7'
   end
 
   alias delegate single_delegate

--- a/test/test_forwardable.rb
+++ b/test/test_forwardable.rb
@@ -16,6 +16,10 @@ class TestForwardable < Test::Unit::TestCase
     def delegated2
       RETURNED2
     end
+
+    def delegated1_kw(**kw)
+      [RETURNED1, kw]
+    end
   end
 
   def test_def_instance_delegator
@@ -35,6 +39,18 @@ class TestForwardable < Test::Unit::TestCase
       end
 
       assert_equal 42, cls.new.to_i
+    end
+  end
+
+  def test_def_instance_delegator_kw
+    %i[def_delegator def_instance_delegator].each do |m|
+      cls = forwardable_class do
+        __send__ m, :@receiver, :delegated1_kw
+      end
+
+      ary = cls.new.delegated1_kw b: 1
+      assert_same RETURNED1, ary[0]
+      assert_equal({b: 1}, ary[1])
     end
   end
 


### PR DESCRIPTION
Do so in a way that is also compatible with previous versions.