### PR TITLE
Update Spelling in README#Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or install it yourself as:
 
 ## Usage
 
-For example, say you have a class RecordCollection which contains an array <tt>@records</tt>.  You could provide the lookup ethod `#record_number()`, which simply calls #[] on the <tt>@records</tt> array, like this:
+For example, say you have a class RecordCollection which contains an array <tt>@records</tt>.  You could provide the lookup method `#record_number()`, which simply calls #[] on the <tt>@records</tt> array, like this:
 
 ```
   require 'forwardable'


### PR DESCRIPTION
Thanks for creating this module for the Ruby community. When I was reading the `README`, I noticed a small typo, so I figured Id offer this PR as an update :smiley:. 

This changes the spelling of `ethod` to be `method` within the `#Usage` section.