### PR TITLE
Make def_*_delegator return name of method defined (Fixes #10)

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -160,6 +160,7 @@ module Forwardable
   # +accessor.method+.  +accessor+ should be a method name, instance
   # variable name, or constant name.  Use the full path to the
   # constant if providing the constant name.
+  # Returns the name of the method defined.
   #
   #   class MyQueue
   #     CONST = 1
@@ -184,8 +185,9 @@ module Forwardable
 
     # If it's not a class or module, it's an instance
     mod = Module === self ? self : singleton_class
-    mod.module_eval(&gen)
+    ret = mod.module_eval(&gen)
     mod.send(:ruby2_keywords, ali) if RUBY_VERSION >= '2.7'
+    ret
   end
 
   alias delegate instance_delegate
@@ -299,11 +301,13 @@ module SingleForwardable
   # Defines a method _method_ which delegates to _accessor_ (i.e. it calls
   # the method of the same name in _accessor_).  If _new_name_ is
   # provided, it is used as the name for the delegate method.
+  # Returns the name of the method defined.
   def def_single_delegator(accessor, method, ali = method)
     gen = Forwardable._delegator_method(self, accessor, method, ali)
 
-    instance_eval(&gen)
+    ret = instance_eval(&gen)
     singleton_class.send(:ruby2_keywords, ali) if RUBY_VERSION >= '2.7'
+    ret
   end
 
   alias delegate single_delegate

--- a/lib/forwardable/version.rb
+++ b/lib/forwardable/version.rb
@@ -1,5 +1,5 @@
 module Forwardable
   # Version of +forwardable.rb+
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
   FORWARDABLE_VERSION = VERSION
 end

--- a/test/test_forwardable.rb
+++ b/test/test_forwardable.rb
@@ -24,11 +24,13 @@ class TestForwardable < Test::Unit::TestCase
 
   def test_def_instance_delegator
     %i[def_delegator def_instance_delegator].each do |m|
+      ret = nil
       cls = forwardable_class do
-        __send__ m, :@receiver, :delegated1
+        ret = __send__ m, :@receiver, :delegated1
       end
 
       assert_same RETURNED1, cls.new.delegated1
+      assert_equal :delegated1, ret
     end
   end
 
@@ -185,11 +187,13 @@ class TestForwardable < Test::Unit::TestCase
 
   def test_class_single_delegator
     %i[def_delegator def_single_delegator].each do |m|
+      ret = nil
       cls = single_forwardable_class do
-        __send__ m, :@receiver, :delegated1
+        ret = __send__ m, :@receiver, :delegated1
       end
 
       assert_same RETURNED1, cls.delegated1
+      assert_equal :delegated1, ret
     end
   end
 


### PR DESCRIPTION
This restores compatibility with previous versions.  This behavior
was previously undefined, but it makes sense for the name of the
defined method to be returned.