### PR TITLE
Update Ruby versions for CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.6.x', '2.5.x', '2.4.x', '2.3.x' ]
+        ruby: [ '2.7.x', '2.6.x', '2.5.x', '2.4.x' ]
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby


### PR DESCRIPTION
Drop 2.3: https://github.com/ruby/forwardable/pull/13/checks?check_run_id=1011498758#step:3:4

Add 2.7: https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/