### PR TITLE
Exclude Ruby 2.4-2.6 from windows-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,13 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            ruby: 2.4
+          - os: windows-latest
+            ruby: 2.5
+          - os: windows-latest
+            ruby: 2.6
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/ruby/forwardable/actions/runs/4507858237/jobs/7936029186